### PR TITLE
Bump published version to 0.0.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,4 +18,4 @@ deploy: output.yml
 	aws cloudformation describe-stacks --stack-name $(STACK_NAME) --query Stacks[].Outputs[].OutputValue --output text
 
 publish: output.yml
-	sam publish -t output.yml --semantic-version 0.0.3
+	sam publish -t output.yml --semantic-version 0.0.4


### PR DESCRIPTION
Just to avoid issues with semantic versioning
<img width="1258" height="82" alt="image" src="https://github.com/user-attachments/assets/d5bcf807-417d-4544-ac74-0c9858ac95c1" />
